### PR TITLE
Fix width with maximized state in mind

### DIFF
--- a/src/hideUsers.scss
+++ b/src/hideUsers.scss
@@ -1,5 +1,5 @@
 :root {
-  --hidden-user-width: 60px;
+  --hidden-user-width: 58px;
   --user-width: 264px;
 }
 


### PR DESCRIPTION
When the window is maximized, a width of 60 would lead to about 2 pixels of the username still showing.

Setting it to 58 is better for both maximized and windowed.

Here's a before>after (Discord maximized on main monitor, Explorer maximized on right monitor):

Before:
<img width="462" height="792" alt="image" src="https://github.com/user-attachments/assets/f21c250a-070f-4f39-8137-cc961c3bb16b" />
After:
<img width="462" height="792" alt="image" src="https://github.com/user-attachments/assets/9ded3f45-514e-4585-90e9-036505daa738" />